### PR TITLE
remove autosaves that can softlock

### DIFF
--- a/itemrandomizer.py
+++ b/itemrandomizer.py
@@ -866,6 +866,19 @@ def apply_fixes_for_randomizer(areaid, data):
         # Remove trampoline at crisis boost location
         data.tiledata_event[xy_to_index(246,63)] = 0
         data.tiledata_event[xy_to_index(246,64)] = 0
+        # Remove three autosaves in the lower halloween area.
+        # Each of these can cause a potential softlock as they are reachable
+        # with slide and explosives, but require at least one more item
+        # to exit the halloween area
+        # The autosave leading to the underwater segment:
+        data.tiledata_event[xy_to_index(158,92)] = 0
+        data.tiledata_event[xy_to_index(158,93)] = 0
+        # The autosave after the underwater segment:
+        data.tiledata_event[xy_to_index(173,97)] = 0
+        data.tiledata_event[xy_to_index(173,98)] = 0
+        data.tiledata_event[xy_to_index(173,99)] = 0
+        # The autosave outside Cicini's room:
+        data.tiledata_event[xy_to_index(199,98)] = 0
 
     if areaid == 4:
         # Remove save point at slide location in lab

--- a/itemrandomizer.py
+++ b/itemrandomizer.py
@@ -879,6 +879,13 @@ def apply_fixes_for_randomizer(areaid, data):
         data.tiledata_event[xy_to_index(173,99)] = 0
         # The autosave outside Cicini's room:
         data.tiledata_event[xy_to_index(199,98)] = 0
+        # Add an autosave at the end of the long room
+        data.tiledata_event[xy_to_index(278,86)] = 42
+        data.tiledata_event[xy_to_index(278,87)] = 42
+        data.tiledata_event[xy_to_index(279,86)] = 44
+        data.tiledata_event[xy_to_index(279,87)] = 44
+        data.tiledata_event[xy_to_index(277,86)] = 44
+        data.tiledata_event[xy_to_index(277,87)] = 44
 
     if areaid == 4:
         # Remove save point at slide location in lab


### PR DESCRIPTION
in the halloween area, three autosave columns can softlock if there is no manual save and the player does not have sufficient items to get out of the area